### PR TITLE
implemented query by name

### DIFF
--- a/service/models/wishlist.py
+++ b/service/models/wishlist.py
@@ -59,8 +59,14 @@ class Wishlist(db.Model, PersistentBase):
         try:
             self.customer_id = data["customer_id"]
             self.name = data["name"]
-            self.created_date = data["created_date"]
-            self.modified_date = data["modified_date"]
+
+            # The dates should always be set by default or on update
+            # Has commented the following block, it is only for tests
+
+            # if data["created_date"]:
+            #     self.created_date = data["created_date"]
+            # if data["modified_date"]:
+            #     self.modified_date = data["modified_date"]
 
             item_list = data.get("items")
             if item_list:

--- a/service/routes.py
+++ b/service/routes.py
@@ -115,8 +115,8 @@ def create_wishlists():
     wishlist = Wishlist()
     wishlist.deserialize(request.get_json())
 
-    if wishlist.find_by_name(wishlist.name):
-        return jsonify({"name": wishlist.name, "status": "Wishlist already exists."}), status.HTTP_409_CONFLICT
+    # if wishlist.find_by_name(wishlist.name):
+    #     return jsonify({"name": wishlist.name, "status": "Wishlist already exists."}), status.HTTP_409_CONFLICT
 
     wishlist.create()
 
@@ -162,7 +162,11 @@ def list_wishlists():
     This endpoint will list all of the Wishlists
     """
     app.logger.info("Request for Wishlist list")
-    wishlists = Wishlist.all()
+    name = request.args.get('name')
+    if name:
+        wishlists = Wishlist.find_by_name(name)
+    else:
+        wishlists = Wishlist.all()
 
     # Return as an array of dictionaries
     results = [wishlist.serialize() for wishlist in wishlists]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -78,10 +78,10 @@ class WishlistService(TestBase):
         )
         self.assertEqual(new_wishlist["items"], wishlist.items, "Items does not match")
 
-        resp = self.client.post(
-            BASE_URL, json=wishlist.serialize(), content_type="application/json"
-        )
-        self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT)
+        # resp = self.client.post(
+        #     BASE_URL, json=wishlist.serialize(), content_type="application/json"
+        # )
+        # self.assertEqual(resp.status_code, status.HTTP_409_CONFLICT)
 
     def test_delete_wishlist(self):
         """It should Delete a wishlist"""
@@ -169,6 +169,49 @@ class WishlistService(TestBase):
         data = resp.get_json()
         logging.debug("Response data = %s", data)
         self.assertIn("was not found", data["message"])
+
+    def test_query_wishlists_by_name(self):
+        """It should query and return a list of wishlists of the specified name"""
+        # create 3 wishlists
+        wishlists = self._create_wishlists(3)
+        resp = self.client.get(f"{BASE_URL}")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        data = resp.get_json()
+        self.assertEqual(len(data), 3)
+
+        # change the names of 2 wishlists as "myWishlist"
+        wishlists[0].name = "myWishlist"
+        wishlists[1].name = "myWishlist"
+        wishlists[2].name = "notMyWishlist"
+
+        # update the wishlists
+        resp = self.client.put(
+            f"{BASE_URL}/{wishlists[0].id}",
+            json=wishlists[0].serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.put(
+            f"{BASE_URL}/{wishlists[1].id}",
+            json=wishlists[1].serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.put(
+            f"{BASE_URL}/{wishlists[2].id}",
+            json=wishlists[2].serialize(),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        resp = self.client.get(f"{BASE_URL}?name=myWishlist")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        data = resp.get_json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(wishlists[0].name, data[0]["name"])
+        self.assertEqual(wishlists[0].name, data[1]["name"])
 
     ######################################################################
     #  WISHLIST ITEMS TEST CASES HERE

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -104,12 +104,20 @@ class TestWishlist(TestBase):
         # delete the wishlist
         wishlist.delete()
         self.assertEqual(len(Wishlist.all()), 0)
+        wishlist.delete()
 
     def test_delete_wishlist_not_found(self):
         """It should not delete a Wishlist that does not exist"""
         wishlist = WishlistFactory()
         wishlist.id = "non-existent-id"  # Set an ID that does not exist in the database
         self.assertEqual(len(Wishlist.all()), 0)
+
+    @patch("service.models.db.session.commit")
+    def test_delete_wishlist_failed(self, exception_mock):
+        """It should not delete a Wishlist on database error"""
+        exception_mock.side_effect = Exception()
+        wishlist = WishlistFactory()
+        self.assertRaises(DataValidationError, wishlist.delete)
 
     def test_update_wishlist(self):
         """It should Update a wishlist"""
@@ -189,9 +197,11 @@ class TestWishlist(TestBase):
         new_wishlist.deserialize(serial_wishlist)
         self.assertEqual(new_wishlist.customer_id, wishlist.customer_id)
         self.assertEqual(new_wishlist.name, wishlist.name)
-        self.assertEqual(new_wishlist.created_date, wishlist.created_date)
-        self.assertEqual(new_wishlist.modified_date, wishlist.modified_date)
         self.assertEqual(len(new_wishlist.items), len(wishlist.items))
+
+        # Do not need to test, only set by default or on update
+        # self.assertEqual(new_wishlist.created_date, wishlist.created_date)
+        # self.assertEqual(new_wishlist.modified_date, wishlist.modified_date)
 
     def test_deserialize_with_key_error(self):
         """It should not Deserialize a wishlist with a KeyError"""


### PR DESCRIPTION
Modified files:
- service/models/wishlist.py: 
  - Suppressed assignment of dates. Should only set by default or on update
- service/routes.py
  - Removed duplicate name constraints.
  - Added "query by name" feature inside list route
- tests/test_routes.py
  - Added "query by name" test cases
- tests/test_wishlist.py
  - Added "test_delete_wishlist_failed"
  - Removed test cases about dates